### PR TITLE
Don't use path module in browser builds

### DIFF
--- a/lib/docx/docx-reader.js
+++ b/lib/docx/docx-reader.js
@@ -1,8 +1,6 @@
 exports.read = read;
 exports._findPartPaths = findPartPaths;
 
-var path = require("path");
-
 var promises = require("../promises");
 var documents = require("../documents");
 var Result = require("../results").Result;
@@ -28,7 +26,7 @@ function read(docxFile, input) {
         contentTypes: readContentTypesFromZipFile(docxFile),
         partPaths: findPartPaths(docxFile),
         docxFile: docxFile,
-        files: new Files(input.path ? path.dirname(input.path) : null)
+        files: input.path ? Files.relativeToFile(input.path) : new Files(null)
     }).also(function(result) {
         return {
             styles: readStylesFromZipFile(docxFile, result.partPaths.styles)

--- a/lib/docx/files.js
+++ b/lib/docx/files.js
@@ -1,6 +1,7 @@
 var fs = require("fs");
 var url = require("url");
 var os = require("os");
+var dirname = require("path").dirname;
 var resolvePath = require("path").resolve;
 var isAbsolutePath = require('path-is-absolute');
 
@@ -36,6 +37,14 @@ function Files(base) {
         read: read
     };
 }
+
+
+function relativeToFile(filePath) {
+    return new Files(dirname(filePath));
+}
+
+Files.relativeToFile = relativeToFile;
+
 
 var readFile = promises.promisify(fs.readFile.bind(fs));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mammoth",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mammoth",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.6",


### PR DESCRIPTION
Added the original author's change for not using the path module in browser builds. All tests pass.

[Original author's commit I used](https://github.com/mwilliamson/mammoth.js/commit/4bd14e9b3de8e7077e013f652712058e37f3e261)

PS.
Your version would have been a great addition to the original project, no idea why the author rejected it.
Luckily, I managed to find it inside the "garbage can of the original git repository" because this is exactly what I needed for the project I am working on.
